### PR TITLE
don't use doseq while blitting

### DIFF
--- a/src/cljs/goya/canvasdrawing.cljs
+++ b/src/cljs/goya/canvasdrawing.cljs
@@ -15,7 +15,7 @@
     (set! (.-height canvas) screen-canvas-height)
     (set! (.-fillStyle context) "#ff0000")
     (.fillRect context 0 0 screen-canvas-width screen-canvas-height)
-    (doseq [x (range 0 pixel-count)]
+    (dotimes [x pixel-count]
       (let [pix-x (* (mod x width) pixel-size)
             pix-y (* (quot x height) pixel-size)
             color (nth pixels x)]


### PR DESCRIPTION
goya.canvasdrawing/draw-image-to-canvas is an inner loop. doseq over a
range is a big performance hit, instead use dotimes which compiles down to
a JavaScript primitive loop.
